### PR TITLE
Supression d'un qui prend en double

### DIFF
--- a/includes/2023/files/02_1/enonce.md
+++ b/includes/2023/files/02_1/enonce.md
@@ -1,4 +1,4 @@
-Écrire une fonction `indices_maxi` qui prend qui prend en paramètre une liste `tab`, non vide, de
+Écrire une fonction `indices_maxi` qui prend en paramètre une liste `tab`, non vide, de
 nombres entiers et renvoie un couple donnant d’une part le plus grand élément de cette
 liste et d’autre part la liste des indices de la liste `tab` où apparaît ce plus grand élément.
 


### PR DESCRIPTION
Correction d’une petite typo (erreur non vu dans le sujet officiel).